### PR TITLE
remove warnings during make and sudo make install

### DIFF
--- a/Install/src/RADProc.cc
+++ b/Install/src/RADProc.cc
@@ -627,7 +627,7 @@ for (int i = 0; i < (int)keys.size(); i++) {
     	consensus[keys[i]]=con;    
     
    }
-
+return 0;
 }
 
 
@@ -2043,7 +2043,7 @@ vector<int> mkeys;
 
 write_catalog(ctags, path);
 ctags.clear();
-
+return 0;
 }
 
 


### PR DESCRIPTION
Hi Praveen, 

including `return 0;` fix those 2 warnings...